### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/04-code-checks.yml
+++ b/.github/workflows/04-code-checks.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   job1:
     name: linting
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo


### PR DESCRIPTION
Potential fix for [https://github.com/broberts23/mslearn-mlops/security/code-scanning/1](https://github.com/broberts23/mslearn-mlops/security/code-scanning/1)

To fix the problem, add a `permissions` block limiting the `GITHUB_TOKEN` to the least privilege it requires. For this workflow/job, only read access to repository contents is necessary (`contents: read`). This can be done either at the workflow root or within the specific job(s). Setting it on the job is clearer for this case, since there is only one job. To make the change, add the following immediately under the `job1:` key and above `runs-on:`.

No new imports, methods, or other variables are required—only an edit to the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
